### PR TITLE
Test/squash 2

### DIFF
--- a/.syncpackrc
+++ b/.syncpackrc
@@ -22,14 +22,7 @@
 			]
 		},
 		{
-			"dependencies": [
-				"@types/react"
-			],
-			"dependencyTypes": [
-				"devDependencies"
-			],
-			"pinVersion": "^17.0.2",
-			"packages": [
+			"dep": [
 				"**"
 			]
 		},

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -14,36 +14,35 @@ Our repository uses [Turborepo](https://turborepo.org) for `build` and `test` co
 
 If you are interested in running a `turbo` command against a single plugin, package, or tool, you can do so with the `--filter` flag. This flag supports the `"name"` option in `package.json` files, paths, and globs.
 
-If you would like to read more about the syntax, please check out [the Turborepo filtering documentation](https://turborepo.org/docs/core-concepts/filtering).
-
-### Examples
-
-Here are some examples of the ways you can use Turborepo / pnpm commands:
-
-```bash
-# Lint and build all plugins, packages, and tools. Note the use of `-r` for lint,
-# turbo does not run the lint at this time.
-pnpm run -r lint && pnpm run build 
+If you would like to read more about the syntax, please check out [the Turborepo filtering documentation](https://turborepo.org/docs/core-concepts/fi& pnpm run build
 
 # Build WooCommerce Core and all of its dependencies
-pnpm run --filter='woocommerce' build 
+
+pnpm run --filter='woocommerce' build
 
 # Lint the @woocommerce/components package - note the different argument order, turbo scripts
+
 # are not running lints at this point in time.
-pnpm run -r --filter='@woocommerce/components' lint 
+
+pnpm run -r --filter='@woocommerce/components' lint
 
 # Test all of the @woocommerce scoped packages
-pnpm run --filter='@woocommerce/*' test 
+
+pnpm run --filter='@woocommerce/\*' test
 
 # Build all of the JavaScript packages
-pnpm run --filter='./packages/js/*' build 
+
+pnpm run --filter='./packages/js/\*' build
 
 # Build everything except WooCommerce Core
-pnpm run --filter='!woocommerce' build 
+
+pnpm run --filter='!woocommerce' build
 
 # Build everything that has changed since the last commit
-pnpm run --filter='[HEAD^1]' build 
-```
+
+pnpm run --filter='[HEAD^1]' build
+
+````
 
 ### Cache busting Turbo
 
@@ -54,7 +53,7 @@ e.g.
 ```bash
 # Force an uncached build of WooCommerce Core and all of its dependencies
 TURBO_FORCE=true pnpm run --filter='woocommerce' build
-```
+````
 
 ## Other Commands
 


### PR DESCRIPTION
### All Submissions:

-   [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1.
2.
3.

<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
